### PR TITLE
[enhancement] add some Emacs-like key bindings in prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/autoload/FlyGrep.vim
+++ b/autoload/FlyGrep.vim
@@ -37,7 +37,7 @@ function! s:flygrep(expr) abort
         redrawstatus
         return
     endif
-    try 
+    try
         syn clear FileNames
     catch
     endtr
@@ -181,8 +181,10 @@ endfunction
 let s:MPT._function_key = {
             \ "\<Tab>" : function('s:next_item'),
             \ "\<ScrollWheelDown>" : function('s:next_item'),
+            \ "\<C-n>" : function('s:next_item'),
             \ "\<S-tab>" : function('s:previous_item'),
             \ "\<ScrollWheelUp>" : function('s:previous_item'),
+            \ "\<C-p>" : function('s:previous_item'),
             \ "\<Return>" : function('s:open_item'),
             \ "\<LeftMouse>" : function('s:move_cursor'),
             \ "\<2-LeftMouse>" : function('s:double_click'),

--- a/autoload/SpaceVim/api/prompt.vim
+++ b/autoload/SpaceVim/api/prompt.vim
@@ -43,13 +43,13 @@ func! s:self._handle_input() abort
             call call(self._function_key[char], [])
             continue
         endif
-        if char ==# "\<Right>" || char == 6
+        if char ==# "\<Right>" || char == 6 || char ==# "\<C-f>"
             let self._prompt.begin = self._prompt.begin . self._prompt.cursor
             let self._prompt.cursor = matchstr(self._prompt.end, '^.')
             let self._prompt.end = substitute(self._prompt.end, '^.', '', 'g')
             call self._build_prompt()
             continue
-        elseif char ==# "\<Left>"  || char == 2
+        elseif char ==# "\<Left>"  || char == 2 || char ==# "\<C-b>"
             if self._prompt.begin !=# ''
                 let self._prompt.end = self._prompt.cursor . self._prompt.end
                 let self._prompt.cursor = matchstr(self._prompt.begin, '.$')
@@ -79,10 +79,10 @@ func! s:self._handle_input() abort
             let self._prompt.cursor = ''
             let self._prompt.end = ''
             call self._build_prompt()
-        elseif char ==# "\<bs>"
+        elseif char ==# "\<bs>" || char ==# "\<C-h>"
             let self._prompt.begin = substitute(self._prompt.begin,'.$','','g')
             call self._build_prompt()
-        elseif char == self._keys.close
+        elseif char == self._keys.close || char ==# "\<C-c>"
             call self.close()
             break
         elseif char ==# "\<FocusLost>" || char ==# "\<FocusGained>" || char2nr(char) == 128

--- a/autoload/SpaceVim/api/prompt.vim
+++ b/autoload/SpaceVim/api/prompt.vim
@@ -60,6 +60,14 @@ func! s:self._handle_input() abort
         elseif char ==# "\<C-w>"
             let self._prompt.begin = substitute(self._prompt.begin,'[^\ .*]\+\s*$','','g')
             call self._build_prompt()
+        elseif char ==# "\<DEL>" || char ==# "\<C-d>"
+            if self._prompt.end !=# self._prompt.cursor
+                let self._prompt.begin = self._prompt.begin . self._prompt.cursor
+                let self._prompt.cursor = matchstr(self._prompt.end, '^.')
+                let self._prompt.end = substitute(self._prompt.end, '^.', '', 'g')
+                let self._prompt.begin = substitute(self._prompt.begin,'.$','','g')
+                call self._build_prompt()
+            endif
         elseif char ==# "\<C-a>"  || char ==# "\<Home>"
             let self._prompt.end = substitute(self._prompt.begin . self._prompt.cursor . self._prompt.end, '^.', '', 'g')
             let self._prompt.cursor = matchstr(self._prompt.begin, '^.')


### PR DESCRIPTION
Thank you for the great tool!

I use Emacs-like key bindings every day in my terminal, such as C-h, C-b, C-n, etc.
So I added them to this tool by changing `autoload/SpaceVim/api/prompt.vim`. 

I'm afraid that I changed wrong file because the file seems to be a part of SpaceVim...
But I'm really glad if you merge my PR.

Best,
Kazuya