### PR TITLE
Fix bug: remove duplicated tag

### DIFF
--- a/doc/FlyGrep.txt
+++ b/doc/FlyGrep.txt
@@ -1,5 +1,5 @@
 *FlyGrep.txt*	Fly grep in vim
-Wang Shidong                                               *FlyGrep* *FlyGrep*
+Wang Shidong                                                         *FlyGrep*
 
 ==============================================================================
 CONTENTS                                                    *FlyGrep-contents*


### PR DESCRIPTION
`:PluginInstall` error message:

```
E154: Duplicate tag "FlyGrep" in file /Users/kordan/.dotfiles/vim/bundle/FlyGrep.vim/doc/FlyGrep.txt
```