### PR TITLE
fix: error message occurs when used without spacevim

### DIFF
--- a/autoload/SpaceVim/logger.vim
+++ b/autoload/SpaceVim/logger.vim
@@ -9,7 +9,7 @@
 let s:LOGGER = SpaceVim#api#import('logger')
 
 call s:LOGGER.set_name('SpaceVim')
-call s:LOGGER.set_level(g:spacevim_debug_level)
+call s:LOGGER.set_level(exists('g:spacevim_debug_level')? g:spacevim_debug_level : 0)
 call s:LOGGER.set_silent(1)
 call s:LOGGER.set_verbose(1)
 


### PR DESCRIPTION
I find that the README of this plugin says that this plugin is expected to be used without spacevim, so I think it should works when lacking of some spacevim's global variables.